### PR TITLE
normalized redis in splacheCache

### DIFF
--- a/src/CacheResolverFuncs.ts
+++ b/src/CacheResolverFuncs.ts
@@ -7,7 +7,6 @@ export async function checkCache (parent: any, args: {id: number}, context: any,
             const returnObj = await client.GET(key);
             if (typeof returnObj === 'string'){
                 const returnObjParsed = JSON.parse(returnObj);
-                console.log('returned from cache')
                 return returnObjParsed
             } 
         }else{


### PR DESCRIPTION
- Observed that the current functionality in splacheCache only connects to a local redis instance
- added a general constructor that accepts a host, port, and password for redis client
- cleared old console logs that were used for testing 